### PR TITLE
Add class methods to simplify subclassing

### DIFF
--- a/DCRoundSwitch/DCRoundSwitch.h
+++ b/DCRoundSwitch/DCRoundSwitch.h
@@ -31,6 +31,10 @@
 @property (nonatomic, copy) NSString *onText;			// default: 'ON' - automatically localized
 @property (nonatomic, copy) NSString *offText;			// default: 'OFF' - automatically localized
 
++ (Class)knobLayerClass;
++ (Class)outlineLayerClass;
++ (Class)toggleLayerClass;
+
 - (void)setOn:(BOOL)newOn animated:(BOOL)animated;
 - (void)setOn:(BOOL)newOn animated:(BOOL)animated ignoreControlEvents:(BOOL)ignoreControlEvents;
 

--- a/DCRoundSwitch/DCRoundSwitch.m
+++ b/DCRoundSwitch/DCRoundSwitch.m
@@ -70,6 +70,18 @@
 	return self;
 }
 
++ (Class)knobLayerClass {
+    return [DCRoundSwitchKnobLayer class];
+}
+
++ (Class)outlineLayerClass {
+    return [DCRoundSwitchOutlineLayer class];
+}
+
++ (Class)toggleLayerClass {
+    return [DCRoundSwitchToggleLayer class];
+}
+
 - (void)setup
 {
 	// this way you can set the background color to black or something similar so it can be seen in IB
@@ -105,17 +117,17 @@
 	// this is the knob, and sits on top of the layer stack. note that the knob shadow is NOT drawn here, it is drawn on the
 	// toggleLayer so it doesn't bleed out over the outlineLayer.
 
-	toggleLayer = [[DCRoundSwitchToggleLayer alloc] initWithOnString:self.onText offString:self.offText onTintColor:[UIColor colorWithRed:0.000 green:0.478 blue:0.882 alpha:1.0]];
+	toggleLayer = [[[[self class] toggleLayerClass] alloc] initWithOnString:self.onText offString:self.offText onTintColor:[UIColor colorWithRed:0.000 green:0.478 blue:0.882 alpha:1.0]];
 	toggleLayer.drawOnTint = NO;
 	toggleLayer.clip = YES;
 	[self.layer addSublayer:toggleLayer];
 	[toggleLayer setNeedsDisplay];
 
-	outlineLayer = [DCRoundSwitchOutlineLayer layer];
+	outlineLayer = [[[self class] outlineLayerClass] layer];
 	[toggleLayer addSublayer:outlineLayer];
 	[outlineLayer setNeedsDisplay];
 
-	knobLayer = [DCRoundSwitchKnobLayer layer];
+	knobLayer = [[[self class] knobLayerClass] layer];
 	[self.layer addSublayer:knobLayer];
 	[knobLayer setNeedsDisplay];
 

--- a/DCRoundSwitchDemo/DCRoundSwitchDemo.xcodeproj/project.pbxproj
+++ b/DCRoundSwitchDemo/DCRoundSwitchDemo.xcodeproj/project.pbxproj
@@ -18,6 +18,8 @@
 		AB6FE60513C420D6006BCDBB /* DCRoundSwitchOutlineLayer.m in Sources */ = {isa = PBXBuildFile; fileRef = AB6FE60013C420D6006BCDBB /* DCRoundSwitchOutlineLayer.m */; };
 		AB6FE60613C420D6006BCDBB /* DCRoundSwitchToggleLayer.m in Sources */ = {isa = PBXBuildFile; fileRef = AB6FE60213C420D6006BCDBB /* DCRoundSwitchToggleLayer.m */; };
 		AB6FE60913C420DF006BCDBB /* QuartzCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AB6FE60813C420DF006BCDBB /* QuartzCore.framework */; };
+		B5FFD9C815762AC60085F0FA /* TestSwitch.m in Sources */ = {isa = PBXBuildFile; fileRef = B5FFD9C715762AC60085F0FA /* TestSwitch.m */; };
+		B5FFD9CC15762AFC0085F0FA /* TestSwitchKnobLayer.m in Sources */ = {isa = PBXBuildFile; fileRef = B5FFD9CB15762AFC0085F0FA /* TestSwitchKnobLayer.m */; };
 		DA7A60B613FEA495000F7F8D /* MainWindow.xib in Resources */ = {isa = PBXBuildFile; fileRef = DA7A60B713FEA495000F7F8D /* MainWindow.xib */; };
 		DA7A60B813FEA4A2000F7F8D /* DCRoundSwitchDemoViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = DA7A60B913FEA4A2000F7F8D /* DCRoundSwitchDemoViewController.xib */; };
 		DA7A60BC13FEA655000F7F8D /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = DA7A60BA13FEA654000F7F8D /* Localizable.strings */; };
@@ -45,6 +47,10 @@
 		AB6FE60113C420D6006BCDBB /* DCRoundSwitchToggleLayer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DCRoundSwitchToggleLayer.h; sourceTree = "<group>"; };
 		AB6FE60213C420D6006BCDBB /* DCRoundSwitchToggleLayer.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = DCRoundSwitchToggleLayer.m; sourceTree = "<group>"; };
 		AB6FE60813C420DF006BCDBB /* QuartzCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = QuartzCore.framework; path = System/Library/Frameworks/QuartzCore.framework; sourceTree = SDKROOT; };
+		B5FFD9C615762AC60085F0FA /* TestSwitch.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TestSwitch.h; sourceTree = "<group>"; };
+		B5FFD9C715762AC60085F0FA /* TestSwitch.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TestSwitch.m; sourceTree = "<group>"; };
+		B5FFD9CA15762AFC0085F0FA /* TestSwitchKnobLayer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TestSwitchKnobLayer.h; sourceTree = "<group>"; };
+		B5FFD9CB15762AFC0085F0FA /* TestSwitchKnobLayer.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TestSwitchKnobLayer.m; sourceTree = "<group>"; };
 		DA7A60B713FEA495000F7F8D /* MainWindow.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = MainWindow.xib; sourceTree = "<group>"; };
 		DA7A60B913FEA4A2000F7F8D /* DCRoundSwitchDemoViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = DCRoundSwitchDemoViewController.xib; sourceTree = "<group>"; };
 		DA7A60BB13FEA655000F7F8D /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/Localizable.strings; sourceTree = "<group>"; };
@@ -104,6 +110,10 @@
 				AB6FE5E713C420A3006BCDBB /* DCRoundSwitchDemoViewController.h */,
 				AB6FE5E813C420A3006BCDBB /* DCRoundSwitchDemoViewController.m */,
 				DA7A60B913FEA4A2000F7F8D /* DCRoundSwitchDemoViewController.xib */,
+				B5FFD9C615762AC60085F0FA /* TestSwitch.h */,
+				B5FFD9C715762AC60085F0FA /* TestSwitch.m */,
+				B5FFD9CA15762AFC0085F0FA /* TestSwitchKnobLayer.h */,
+				B5FFD9CB15762AFC0085F0FA /* TestSwitchKnobLayer.m */,
 				DA7A60BA13FEA654000F7F8D /* Localizable.strings */,
 				AB6FE5D913C420A3006BCDBB /* Supporting Files */,
 			);
@@ -205,6 +215,8 @@
 				AB6FE60413C420D6006BCDBB /* DCRoundSwitchKnobLayer.m in Sources */,
 				AB6FE60513C420D6006BCDBB /* DCRoundSwitchOutlineLayer.m in Sources */,
 				AB6FE60613C420D6006BCDBB /* DCRoundSwitchToggleLayer.m in Sources */,
+				B5FFD9C815762AC60085F0FA /* TestSwitch.m in Sources */,
+				B5FFD9CC15762AFC0085F0FA /* TestSwitchKnobLayer.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/DCRoundSwitchDemo/DCRoundSwitchDemo/DCRoundSwitchDemoViewController.xib
+++ b/DCRoundSwitchDemo/DCRoundSwitchDemo/DCRoundSwitchDemoViewController.xib
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <archive type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="7.10">
 	<data>
-		<int key="IBDocument.SystemTarget">1056</int>
-		<string key="IBDocument.SystemVersion">10K540</string>
-		<string key="IBDocument.InterfaceBuilderVersion">1306</string>
-		<string key="IBDocument.AppKitVersion">1038.36</string>
-		<string key="IBDocument.HIToolboxVersion">461.00</string>
+		<int key="IBDocument.SystemTarget">1296</int>
+		<string key="IBDocument.SystemVersion">11E53</string>
+		<string key="IBDocument.InterfaceBuilderVersion">2182</string>
+		<string key="IBDocument.AppKitVersion">1138.47</string>
+		<string key="IBDocument.HIToolboxVersion">569.00</string>
 		<object class="NSMutableDictionary" key="IBDocument.PluginVersions">
 			<string key="NS.key.0">com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
-			<string key="NS.object.0">301</string>
+			<string key="NS.object.0">1179</string>
 		</object>
 		<object class="NSArray" key="IBDocument.IntegratedClassDependencies">
 			<bool key="EncodedWithXMLCoder">YES</bool>
@@ -20,11 +20,8 @@
 			<string>com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
 		</object>
 		<object class="NSMutableDictionary" key="IBDocument.Metadata">
-			<bool key="EncodedWithXMLCoder">YES</bool>
-			<object class="NSArray" key="dict.sortedKeys" id="0">
-				<bool key="EncodedWithXMLCoder">YES</bool>
-			</object>
-			<reference key="dict.values" ref="0"/>
+			<string key="NS.key.0">PluginDependencyRecalculationVersion</string>
+			<integer value="1" key="NS.object.0"/>
 		</object>
 		<object class="NSMutableArray" key="IBDocument.RootObjects" id="1000">
 			<bool key="EncodedWithXMLCoder">YES</bool>
@@ -47,7 +44,7 @@
 						<string key="NSFrame">{{72, 55}, {77, 27}}</string>
 						<reference key="NSSuperview" ref="774585933"/>
 						<reference key="NSWindow"/>
-						<reference key="NSNextKeyView"/>
+						<reference key="NSNextKeyView" ref="626979439"/>
 						<object class="NSColor" key="IBUIBackgroundColor" id="937704349">
 							<int key="NSColorSpace">1</int>
 							<bytes key="NSRGB">MCAwIDEAA</bytes>
@@ -61,6 +58,7 @@
 						<string key="NSFrame">{{72, 102}, {77, 27}}</string>
 						<reference key="NSSuperview" ref="774585933"/>
 						<reference key="NSWindow"/>
+						<reference key="NSNextKeyView" ref="274290686"/>
 						<reference key="IBUIBackgroundColor" ref="937704349"/>
 						<string key="targetRuntimeIdentifier">IBCocoaTouchFramework</string>
 					</object>
@@ -70,6 +68,7 @@
 						<string key="NSFrame">{{72, 150}, {77, 27}}</string>
 						<reference key="NSSuperview" ref="774585933"/>
 						<reference key="NSWindow"/>
+						<reference key="NSNextKeyView" ref="284646989"/>
 						<reference key="IBUIBackgroundColor" ref="937704349"/>
 						<string key="targetRuntimeIdentifier">IBCocoaTouchFramework</string>
 					</object>
@@ -79,6 +78,7 @@
 						<string key="NSFrame">{{172, 55}, {77, 27}}</string>
 						<reference key="NSSuperview" ref="774585933"/>
 						<reference key="NSWindow"/>
+						<reference key="NSNextKeyView" ref="499357928"/>
 						<reference key="IBUIBackgroundColor" ref="937704349"/>
 						<int key="IBUITag">1</int>
 						<string key="targetRuntimeIdentifier">IBCocoaTouchFramework</string>
@@ -89,6 +89,7 @@
 						<string key="NSFrame">{{172, 102}, {77, 27}}</string>
 						<reference key="NSSuperview" ref="774585933"/>
 						<reference key="NSWindow"/>
+						<reference key="NSNextKeyView" ref="271861132"/>
 						<reference key="IBUIBackgroundColor" ref="937704349"/>
 						<string key="targetRuntimeIdentifier">IBCocoaTouchFramework</string>
 					</object>
@@ -98,6 +99,7 @@
 						<string key="NSFrame">{{172, 150}, {77, 27}}</string>
 						<reference key="NSSuperview" ref="774585933"/>
 						<reference key="NSWindow"/>
+						<reference key="NSNextKeyView" ref="984913354"/>
 						<reference key="IBUIBackgroundColor" ref="937704349"/>
 						<string key="targetRuntimeIdentifier">IBCocoaTouchFramework</string>
 					</object>
@@ -107,6 +109,7 @@
 						<string key="NSFrame">{{53, 209}, {214, 95}}</string>
 						<reference key="NSSuperview" ref="774585933"/>
 						<reference key="NSWindow"/>
+						<reference key="NSNextKeyView" ref="984828875"/>
 						<reference key="IBUIBackgroundColor" ref="937704349"/>
 						<string key="targetRuntimeIdentifier">IBCocoaTouchFramework</string>
 					</object>
@@ -116,7 +119,19 @@
 						<string key="NSFrame">{{23, 326}, {275, 28}}</string>
 						<reference key="NSSuperview" ref="774585933"/>
 						<reference key="NSWindow"/>
+						<reference key="NSNextKeyView" ref="107090757"/>
 						<reference key="IBUIBackgroundColor" ref="937704349"/>
+						<string key="targetRuntimeIdentifier">IBCocoaTouchFramework</string>
+					</object>
+					<object class="IBUIView" id="107090757">
+						<reference key="NSNextResponder" ref="774585933"/>
+						<int key="NSvFlags">274</int>
+						<string key="NSFrame">{{122, 376}, {77, 27}}</string>
+						<reference key="NSSuperview" ref="774585933"/>
+						<reference key="NSWindow"/>
+						<reference key="NSNextKeyView"/>
+						<reference key="IBUIBackgroundColor" ref="937704349"/>
+						<int key="IBUITag">1</int>
 						<string key="targetRuntimeIdentifier">IBCocoaTouchFramework</string>
 					</object>
 				</object>
@@ -190,7 +205,9 @@
 					<bool key="EncodedWithXMLCoder">YES</bool>
 					<object class="IBObjectRecord">
 						<int key="objectID">0</int>
-						<reference key="object" ref="0"/>
+						<object class="NSArray" key="object" id="0">
+							<bool key="EncodedWithXMLCoder">YES</bool>
+						</object>
 						<reference key="children" ref="1000"/>
 						<nil key="parent"/>
 					</object>
@@ -218,6 +235,7 @@
 							<reference ref="626979439"/>
 							<reference ref="274290686"/>
 							<reference ref="284646989"/>
+							<reference ref="107090757"/>
 						</object>
 						<reference key="parent" ref="0"/>
 					</object>
@@ -261,6 +279,11 @@
 						<reference key="object" ref="284646989"/>
 						<reference key="parent" ref="774585933"/>
 					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">45</int>
+						<reference key="object" ref="107090757"/>
+						<reference key="parent" ref="774585933"/>
+					</object>
 				</object>
 			</object>
 			<object class="NSMutableDictionary" key="flattenedProperties">
@@ -268,7 +291,9 @@
 				<object class="NSArray" key="dict.sortedKeys">
 					<bool key="EncodedWithXMLCoder">YES</bool>
 					<string>-1.CustomClassName</string>
+					<string>-1.IBPluginDependency</string>
 					<string>-2.CustomClassName</string>
+					<string>-2.IBPluginDependency</string>
 					<string>33.CustomClassName</string>
 					<string>33.IBPluginDependency</string>
 					<string>35.CustomClassName</string>
@@ -281,18 +306,19 @@
 					<string>40.IBPluginDependency</string>
 					<string>41.CustomClassName</string>
 					<string>41.IBPluginDependency</string>
-					<string>6.IBEditorWindowLastContentRect</string>
+					<string>45.CustomClassName</string>
+					<string>45.IBPluginDependency</string>
 					<string>6.IBPluginDependency</string>
 					<string>8.CustomClassName</string>
 					<string>8.IBPluginDependency</string>
 					<string>9.CustomClassName</string>
 					<string>9.IBPluginDependency</string>
 				</object>
-				<object class="NSMutableArray" key="dict.values">
+				<object class="NSArray" key="dict.values">
 					<bool key="EncodedWithXMLCoder">YES</bool>
 					<string>DCRoundSwitchDemoViewController</string>
+					<string>com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
 					<string>UIResponder</string>
-					<string>DCRoundSwitch</string>
 					<string>com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
 					<string>DCRoundSwitch</string>
 					<string>com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
@@ -304,7 +330,10 @@
 					<string>com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
 					<string>DCRoundSwitch</string>
 					<string>com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
-					<string>{{239, 654}, {320, 480}}</string>
+					<string>DCRoundSwitch</string>
+					<string>com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
+					<string>TestSwitch</string>
+					<string>com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
 					<string>com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
 					<string>DCRoundSwitch</string>
 					<string>com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
@@ -324,7 +353,7 @@
 				<reference key="dict.values" ref="0"/>
 			</object>
 			<nil key="sourceID"/>
-			<int key="maxID">44</int>
+			<int key="maxID">45</int>
 		</object>
 		<object class="IBClassDescriber" key="IBDocument.Classes">
 			<object class="NSMutableArray" key="referencedPartialClassDescriptions">
@@ -350,7 +379,7 @@
 							<string>switch2</string>
 							<string>switch3</string>
 						</object>
-						<object class="NSMutableArray" key="dict.values">
+						<object class="NSArray" key="dict.values">
 							<bool key="EncodedWithXMLCoder">YES</bool>
 							<string>DCRoundSwitch</string>
 							<string>DCRoundSwitch</string>
@@ -369,7 +398,7 @@
 							<string>switch2</string>
 							<string>switch3</string>
 						</object>
-						<object class="NSMutableArray" key="dict.values">
+						<object class="NSArray" key="dict.values">
 							<bool key="EncodedWithXMLCoder">YES</bool>
 							<object class="IBToOneOutletInfo">
 								<string key="name">fatSwitch</string>
@@ -398,16 +427,28 @@
 						<string key="minorKey">./Classes/DCRoundSwitchDemoViewController.h</string>
 					</object>
 				</object>
+				<object class="IBPartialClassDescription">
+					<string key="className">TestSwitch</string>
+					<string key="superclassName">DCRoundSwitch</string>
+					<object class="IBClassDescriptionSource" key="sourceIdentifier">
+						<string key="majorKey">IBProjectSource</string>
+						<string key="minorKey">./Classes/TestSwitch.h</string>
+					</object>
+				</object>
 			</object>
 		</object>
 		<int key="IBDocument.localizationMode">0</int>
 		<string key="IBDocument.TargetRuntimeIdentifier">IBCocoaTouchFramework</string>
+		<object class="NSMutableDictionary" key="IBDocument.PluginDeclaredDependencyDefaults">
+			<string key="NS.key.0">com.apple.InterfaceBuilder.CocoaTouchPlugin.iPhoneOS</string>
+			<real value="1296" key="NS.object.0"/>
+		</object>
 		<object class="NSMutableDictionary" key="IBDocument.PluginDeclaredDevelopmentDependencies">
 			<string key="NS.key.0">com.apple.InterfaceBuilder.CocoaTouchPlugin.InterfaceBuilder3</string>
 			<integer value="3100" key="NS.object.0"/>
 		</object>
 		<bool key="IBDocument.PluginDeclaredDependenciesTrackSystemTargetVersion">YES</bool>
 		<int key="IBDocument.defaultPropertyAccessControl">3</int>
-		<string key="IBCocoaTouchPluginVersion">301</string>
+		<string key="IBCocoaTouchPluginVersion">1179</string>
 	</data>
 </archive>

--- a/DCRoundSwitchDemo/DCRoundSwitchDemo/TestSwitch.h
+++ b/DCRoundSwitchDemo/DCRoundSwitchDemo/TestSwitch.h
@@ -1,0 +1,12 @@
+//
+//  TestSwitch.h
+//  DCRoundSwitchDemo
+//
+//  Created by Pete Callaway on 30/05/2012.
+//
+
+#import "DCRoundSwitch.h"
+
+@interface TestSwitch : DCRoundSwitch
+
+@end

--- a/DCRoundSwitchDemo/DCRoundSwitchDemo/TestSwitch.m
+++ b/DCRoundSwitchDemo/DCRoundSwitchDemo/TestSwitch.m
@@ -1,0 +1,18 @@
+//
+//  TestSwitch.m
+//  DCRoundSwitchDemo
+//
+//  Created by Pete Callaway on 30/05/2012.
+//
+
+#import "TestSwitch.h"
+#import "TestSwitchKnobLayer.h"
+
+
+@implementation TestSwitch
+
++ (Class)knobLayerClass {
+    return [TestSwitchKnobLayer class];
+}
+
+@end

--- a/DCRoundSwitchDemo/DCRoundSwitchDemo/TestSwitchKnobLayer.h
+++ b/DCRoundSwitchDemo/DCRoundSwitchDemo/TestSwitchKnobLayer.h
@@ -1,0 +1,12 @@
+//
+//  TestSwitchKnobLayer.h
+//  DCRoundSwitchDemo
+//
+//  Created by Pete Callaway on 30/05/2012.
+//
+
+#import "DCRoundSwitchKnobLayer.h"
+
+@interface TestSwitchKnobLayer : DCRoundSwitchKnobLayer
+
+@end

--- a/DCRoundSwitchDemo/DCRoundSwitchDemo/TestSwitchKnobLayer.m
+++ b/DCRoundSwitchDemo/DCRoundSwitchDemo/TestSwitchKnobLayer.m
@@ -1,0 +1,19 @@
+//
+//  TestSwitchKnobLayer.m
+//  DCRoundSwitchDemo
+//
+//  Created by Pete Callaway on 30/05/2012.
+//
+
+#import "TestSwitchKnobLayer.h"
+
+
+@implementation TestSwitchKnobLayer
+
+- (void)drawInContext:(CGContextRef)context {
+	CGContextSetFillColorWithColor(context, [UIColor redColor].CGColor);
+    CGContextFillEllipseInRect(context, CGRectInset(self.bounds, 2, 2));
+	CGContextSetShadowWithColor(context, CGSizeMake(0, 0), 0, NULL);
+}
+
+@end


### PR DESCRIPTION
I needed to change the look of the knob layer in an app I was developing but there was no simple way to do this.

These commits add class methods to the switch that allow subclasses to specify different classes to use for each layer. I've added an example switch subclass to the demo app to show how these would be used.
