### PR TITLE
Added "off" tint color property

### DIFF
--- a/DCRoundSwitch/DCRoundSwitch.h
+++ b/DCRoundSwitch/DCRoundSwitch.h
@@ -19,6 +19,7 @@
 @interface DCRoundSwitch : UIControl
 
 @property (nonatomic, retain) UIColor *onTintColor;		// default: blue (matches normal UISwitch)
+@property (nonatomic, retain) UIColor *offTintColor;	// default: white (matches normal UISwitch)
 @property (nonatomic, getter=isOn) BOOL on;				// default: NO
 @property (nonatomic, copy) NSString *onText;			// default: 'ON' - automatically localized
 @property (nonatomic, copy) NSString *offText;			// default: 'OFF' - automatically localized

--- a/DCRoundSwitch/DCRoundSwitch.h
+++ b/DCRoundSwitch/DCRoundSwitch.h
@@ -23,6 +23,7 @@
 @property (nonatomic, getter=isOn) BOOL on;				// default: NO
 @property (nonatomic, copy) NSString *onText;			// default: 'ON' - automatically localized
 @property (nonatomic, copy) NSString *offText;			// default: 'OFF' - automatically localized
+@property (nonatomic, copy) NSString *userID;			// default: 'OFF' - automatically localized
 
 + (Class)knobLayerClass;
 + (Class)outlineLayerClass;

--- a/DCRoundSwitch/DCRoundSwitch.m
+++ b/DCRoundSwitch/DCRoundSwitch.m
@@ -32,7 +32,7 @@
 @implementation DCRoundSwitch
 @synthesize outlineLayer, toggleLayer, knobLayer, clipLayer, ignoreTap;
 @synthesize on, onText, offText;
-@synthesize onTintColor;
+@synthesize onTintColor, offTintColor;
 
 #pragma mark -
 #pragma mark Init & Memory Managment
@@ -45,6 +45,7 @@
 	[clipLayer release];
 
 	[onTintColor release];
+    [offTintColor release];
 	[onText release];
 	[offText release];
 
@@ -115,7 +116,7 @@
 	// the switch has three layers, (ordered from bottom to top):
 	//
 	// * toggleLayer * (bottom of the layer stack)
-	// this layer contains the onTintColor (blue by default), the text, and the shadown for the knob.  the knob shadow is
+	// this layer contains the onTintColor (blue by default), and the offTintColor (off-white by default), the text, and the shadown for the knob.  the knob shadow is
 	// on this layer because it needs to go under the outlineLayer so it doesn't bleed out over the edge of the control.
 	// this layer moves when the switch moves
 
@@ -129,7 +130,7 @@
 	// this is the knob, and sits on top of the layer stack. note that the knob shadow is NOT drawn here, it is drawn on the
 	// toggleLayer so it doesn't bleed out over the outlineLayer.
 
-	self.toggleLayer = [[[[[self class] toggleLayerClass] alloc] initWithOnString:self.onText offString:self.offText onTintColor:[UIColor colorWithRed:0.000 green:0.478 blue:0.882 alpha:1.0]] autorelease];
+	self.toggleLayer = [[[[[self class] toggleLayerClass] alloc] initWithOnString:self.onText offString:self.offText onTintColor:[UIColor colorWithRed:0.000 green:0.478 blue:0.882 alpha:1.0] offTintColor:[UIColor colorWithWhite:0.963 alpha:1.0]] autorelease];
 	self.toggleLayer.drawOnTint = NO;
 	self.toggleLayer.clip = YES;
 	[self.layer addSublayer:self.toggleLayer];
@@ -413,6 +414,17 @@
 		[onTintColor release];
 		onTintColor = [anOnTintColor retain];
 		self.toggleLayer.onTintColor = anOnTintColor;
+		[self.toggleLayer setNeedsDisplay];
+	}
+}
+
+- (void)setOffTintColor:(UIColor *)anOffTintColor
+{
+	if (anOffTintColor != offTintColor)
+	{
+		[offTintColor release];
+		offTintColor = [anOffTintColor retain];
+		self.toggleLayer.offTintColor = anOffTintColor;
 		[self.toggleLayer setNeedsDisplay];
 	}
 }

--- a/DCRoundSwitch/DCRoundSwitch.m
+++ b/DCRoundSwitch/DCRoundSwitch.m
@@ -33,6 +33,7 @@
 @synthesize outlineLayer, toggleLayer, knobLayer, clipLayer, ignoreTap;
 @synthesize on, onText, offText;
 @synthesize onTintColor, offTintColor;
+@synthesize userID;
 
 #pragma mark -
 #pragma mark Init & Memory Managment

--- a/DCRoundSwitch/DCRoundSwitch.m
+++ b/DCRoundSwitch/DCRoundSwitch.m
@@ -432,7 +432,7 @@
 - (void)layoutSubviews;
 {
 	CGFloat knobRadius = self.bounds.size.height + 2.0;
-	self.knobLayer.frame = CGRectMake(0, 0, knobRadius, knobRadius);
+	self.knobLayer.frame = CGRectMake(0, 0, knobRadius - 2.0, knobRadius);
 	CGSize toggleSize = CGSizeMake(self.bounds.size.width * 2 - (knobRadius - 4), self.bounds.size.height);
 	CGFloat minToggleX = -toggleSize.width / 2.0 + knobRadius / 2.0 - 1;
 	CGFloat maxToggleX = -1;

--- a/DCRoundSwitch/DCRoundSwitchToggleLayer.h
+++ b/DCRoundSwitch/DCRoundSwitchToggleLayer.h
@@ -15,12 +15,13 @@
 @interface DCRoundSwitchToggleLayer : CALayer
 
 @property (nonatomic, retain) UIColor *onTintColor;
+@property (nonatomic, retain) UIColor *offTintColor;
 @property (nonatomic, retain) NSString *onString;
 @property (nonatomic, retain) NSString *offString;
 @property (nonatomic, readonly) UIFont *labelFont;
 @property (nonatomic) BOOL drawOnTint;
 @property (nonatomic) BOOL clip;
 
-- (id)initWithOnString:(NSString *)anOnString offString:(NSString *)anOffString onTintColor:(UIColor *)anOnTintColor;
+- (id)initWithOnString:(NSString *)anOnString offString:(NSString *)anOffString onTintColor:(UIColor *)anOnTintColor offTintColor:(UIColor *)anOffTintColor;
 
 @end

--- a/DCRoundSwitch/DCRoundSwitchToggleLayer.m
+++ b/DCRoundSwitch/DCRoundSwitchToggleLayer.m
@@ -12,7 +12,7 @@
 #import "DCRoundSwitchToggleLayer.h"
 
 @implementation DCRoundSwitchToggleLayer
-@synthesize onString, offString, onTintColor;
+@synthesize onString, offString, onTintColor, offTintColor;
 @synthesize drawOnTint;
 @synthesize clip;
 @synthesize labelFont;
@@ -22,17 +22,19 @@
 	[onString release];
 	[offString release];
 	[onTintColor release];
+    [offTintColor release];
 
 	[super dealloc];
 }
 
-- (id)initWithOnString:(NSString *)anOnString offString:(NSString *)anOffString onTintColor:(UIColor *)anOnTintColor
+- (id)initWithOnString:(NSString *)anOnString offString:(NSString *)anOffString onTintColor:(UIColor *)anOnTintColor offTintColor:(UIColor *)anOffTintColor
 {
 	if ((self = [super init]))
 	{
 		self.onString = anOnString;
 		self.offString = anOffString;
 		self.onTintColor = anOnTintColor;
+        self.offTintColor = anOffTintColor;
 	}
 
 	return self;
@@ -64,7 +66,7 @@
 	}
 
 	// off tint color (white)
-	CGContextSetFillColorWithColor(context, [UIColor colorWithWhite:0.963 alpha:1.0].CGColor);
+	CGContextSetFillColorWithColor(context, self.offTintColor.CGColor);
 	CGContextFillRect(context, CGRectMake(knobCenter, 0, self.bounds.size.width - knobCenter, self.bounds.size.height));
 
 	// knob shadow


### PR DESCRIPTION
I added a new property that allows users to change the default off-white color of the "off" state.  This can be useful when you use the DCRoundSwitch as a selector between two different items, and not just as an on/off switch.
