### PR TITLE
Arc fixes

### DIFF
--- a/DCRoundSwitch/DCRoundSwitch.m
+++ b/DCRoundSwitch/DCRoundSwitch.m
@@ -37,7 +37,7 @@
 #pragma mark -
 #pragma mark Init & Memory Managment
 
-- (void)dealloc
+/*- (void)dealloc
 {
 	[outlineLayer release];
 	[toggleLayer release];
@@ -49,7 +49,7 @@
 	[offText release];
 
 	[super dealloc];
-}
+}*/
 
 - (id)init
 {
@@ -129,7 +129,7 @@
 	// this is the knob, and sits on top of the layer stack. note that the knob shadow is NOT drawn here, it is drawn on the
 	// toggleLayer so it doesn't bleed out over the outlineLayer.
 
-	self.toggleLayer = [[[[[self class] toggleLayerClass] alloc] initWithOnString:self.onText offString:self.offText onTintColor:[UIColor colorWithRed:0.000 green:0.478 blue:0.882 alpha:1.0]] autorelease];
+	self.toggleLayer = [[[[self class] toggleLayerClass] alloc] initWithOnString:self.onText offString:self.offText onTintColor:[UIColor colorWithRed:0.000 green:0.478 blue:0.882 alpha:1.0]];
 	self.toggleLayer.drawOnTint = NO;
 	self.toggleLayer.clip = YES;
 	[self.layer addSublayer:self.toggleLayer];
@@ -146,14 +146,14 @@
 	self.toggleLayer.contentsScale = self.outlineLayer.contentsScale = self.knobLayer.contentsScale = [[UIScreen mainScreen] scale];
 
 	// tap gesture for toggling the switch
-	UITapGestureRecognizer *tapGestureRecognizer = [[[UITapGestureRecognizer alloc] initWithTarget:self 
-																						   action:@selector(tapped:)] autorelease];
+	UITapGestureRecognizer *tapGestureRecognizer = [[UITapGestureRecognizer alloc] initWithTarget:self 
+																						   action:@selector(tapped:)];
 	[tapGestureRecognizer setDelegate:self];
 	[self addGestureRecognizer:tapGestureRecognizer];
 
 	// pan gesture for moving the switch knob manually
-	UIPanGestureRecognizer *panGestureRecognizer = [[[UIPanGestureRecognizer alloc] initWithTarget:self
-																				 action:@selector(toggleDragged:)] autorelease];
+	UIPanGestureRecognizer *panGestureRecognizer = [[UIPanGestureRecognizer alloc] initWithTarget:self
+																				 action:@selector(toggleDragged:)];
 	[panGestureRecognizer setDelegate:self];
 	[self addGestureRecognizer:panGestureRecognizer];
 
@@ -353,7 +353,7 @@
 	[self positionLayersAndMask];
 
 	// retain all our targets so they don't disappear before the actions get sent at the end of the animation
-	[[self allTargets] makeObjectsPerformSelector:@selector(retain)];
+	//[[self allTargets] makeObjectsPerformSelector:@selector(retain)];
 
 	[CATransaction setCompletionBlock:^{
 		[CATransaction begin];
@@ -399,7 +399,7 @@
 			if (previousOn != on && !ignoreControlEvents)
 				[self sendActionsForControlEvents:UIControlEventValueChanged];
 
-			[[self allTargets] makeObjectsPerformSelector:@selector(release)];
+			//[[self allTargets] makeObjectsPerformSelector:@selector(release)];
 		}];
 
 		[CATransaction commit];
@@ -410,8 +410,8 @@
 {
 	if (anOnTintColor != onTintColor)
 	{
-		[onTintColor release];
-		onTintColor = [anOnTintColor retain];
+		//[onTintColor release];
+		onTintColor = [anOnTintColor copy];
 		self.toggleLayer.onTintColor = anOnTintColor;
 		[self.toggleLayer setNeedsDisplay];
 	}
@@ -447,7 +447,7 @@
 {
 	if (newOnText != onText)
 	{
-		[onText release];
+		//[onText release];
 		onText = [newOnText copy];
 		self.toggleLayer.onString = onText;
 		[self.toggleLayer setNeedsDisplay];
@@ -458,7 +458,7 @@
 {
 	if (newOffText != offText)
 	{
-		[offText release];
+		//[offText release];
 		offText = [newOffText copy];
 		self.toggleLayer.offString = offText;
 		[self.toggleLayer setNeedsDisplay];

--- a/DCRoundSwitch/DCRoundSwitchKnobLayer.m
+++ b/DCRoundSwitch/DCRoundSwitchKnobLayer.m
@@ -11,7 +11,7 @@
 
 #import "DCRoundSwitchKnobLayer.h"
 
-CGGradientRef CreateGradientRefWithColors(CGColorSpaceRef colorSpace, CGColorRef startColor, CGColorRef endColor);
+CGGradientRef CreateGradientRefWithColors(CGColorSpaceRef colorSpace, UIColor* startColor, UIColor* endColor);
 
 @implementation DCRoundSwitchKnobLayer
 @synthesize gripped;
@@ -31,8 +31,8 @@ CGGradientRef CreateGradientRefWithColors(CGColorSpaceRef colorSpace, CGColorRef
 	// knob inner gradient
 	CGContextAddEllipseInRect(context, knobRect);
 	CGContextClip(context);
-	CGColorRef knobStartColor = [UIColor colorWithWhite:0.82 alpha:1.0].CGColor;
-	CGColorRef knobEndColor = (self.gripped) ? [UIColor colorWithWhite:0.894 alpha:1.0].CGColor : [UIColor colorWithWhite:0.996 alpha:1.0].CGColor;
+	UIColor* knobStartColor = [UIColor colorWithWhite:0.82 alpha:1.0];
+	UIColor* knobEndColor = (self.gripped) ? [UIColor colorWithWhite:0.894 alpha:1.0] : [UIColor colorWithWhite:0.996 alpha:1.0];
 	CGPoint topPoint = CGPointMake(0, 0);
 	CGPoint bottomPoint = CGPointMake(0, knobRadius + 2);
 	CGGradientRef knobGradient = CreateGradientRefWithColors(colorSpace, knobStartColor, knobEndColor);
@@ -43,20 +43,19 @@ CGGradientRef CreateGradientRefWithColors(CGColorSpaceRef colorSpace, CGColorRef
 	CGContextAddEllipseInRect(context, CGRectInset(knobRect, 0.5, 0.5));
 	CGContextAddEllipseInRect(context, CGRectInset(knobRect, 1.5, 1.5));
 	CGContextEOClip(context);
-	CGGradientRef knobHighlightGradient = CreateGradientRefWithColors(colorSpace, [UIColor whiteColor].CGColor, [UIColor colorWithWhite:1.0 alpha:0.5].CGColor);
+	CGGradientRef knobHighlightGradient = CreateGradientRefWithColors(colorSpace, [UIColor whiteColor], [UIColor colorWithWhite:1.0 alpha:0.5]);
 	CGContextDrawLinearGradient(context, knobHighlightGradient, topPoint, bottomPoint, 0);
 	CGGradientRelease(knobHighlightGradient);
 
 	CGColorSpaceRelease(colorSpace);
 }
 
-CGGradientRef CreateGradientRefWithColors(CGColorSpaceRef colorSpace, CGColorRef startColor, CGColorRef endColor)
+CGGradientRef CreateGradientRefWithColors(CGColorSpaceRef colorSpace, UIColor* startColor, UIColor* endColor)
 {
 	CGFloat colorStops[2] = {0.0, 1.0};
-	CGColorRef colors[] = {startColor, endColor};
-	CFArrayRef colorsArray = CFArrayCreate(NULL, (const void**)colors, sizeof(colors) / sizeof(CGColorRef), &kCFTypeArrayCallBacks);
-	CGGradientRef gradient = CGGradientCreateWithColors(colorSpace, colorsArray, colorStops);
-	CFRelease(colorsArray);
+	NSArray *colors = [NSArray arrayWithObjects:(__bridge id)startColor.CGColor, (__bridge id) endColor.CGColor, nil];
+	CGGradientRef gradient = CGGradientCreateWithColors(colorSpace, (__bridge CFArrayRef)(colors), colorStops);
+
 	return gradient;
 }
 

--- a/DCRoundSwitch/DCRoundSwitchToggleLayer.m
+++ b/DCRoundSwitch/DCRoundSwitchToggleLayer.m
@@ -17,14 +17,14 @@
 @synthesize clip;
 @synthesize labelFont;
 
-- (void)dealloc
+/*- (void)dealloc
 {
 	[onString release];
 	[offString release];
 	[onTintColor release];
 
 	[super dealloc];
-}
+}*/
 
 - (id)initWithOnString:(NSString *)anOnString offString:(NSString *)anOffString onTintColor:(UIColor *)anOnTintColor
 {


### PR DESCRIPTION
Removed dealloc
Removed autorelease
Fixed Bad Access by using UIColor\* rather than CGColorRef. The compiler sets the original UIColor to be released too early so converting it to a CGColorRef later gets around this
